### PR TITLE
Allow to prefer IPv4 address for IRC-Server if Socket6 is installed.

### DIFF
--- a/cgiirc.config.full
+++ b/cgiirc.config.full
@@ -76,8 +76,8 @@ socket_prefix = /tmp/cgiirc-
 # For IPv6
 #vhost6 = 
 
-# Prefer IPv6 addresses if both addresses resolve (default is IPv4).
-#prefer_v6 = 0 (XXX: This option does not currently work)
+# Prefer IPv4 addresses if both addresses resolve (default is IPv6 if Socket6 is installed).
+prefer_v4 = 0
 
 # -----
 # Access related settings

--- a/nph-irc.cgi
+++ b/nph-irc.cgi
@@ -80,16 +80,21 @@ sub net_hostlookup {
    my($host) = @_;
 
    if($::IPV6) {
-      my($family,$socktype, $proto, $saddr, $canonname, @res) = 
-      getaddrinfo($host, undef, AF_UNSPEC, SOCK_STREAM);
-      return undef unless $family;
-      my($addr, $port) = getnameinfo($saddr, NI_NUMERICHOST | NI_NUMERICSERV);
-=pod
-      my $ip = config_set('prefer_v6') 
-         ? ($ipv6 ? $ipv6 : $ipv4) 
-         : ($ipv4 ? $ipv4 : $ipv6);
-=cut
-      return $addr;
+      my ($ipv6, $ipv4);
+
+      my @res = getaddrinfo($host, undef, AF_UNSPEC, SOCK_STREAM);
+      while (scalar(@res) >= 5) {
+         (my $family, undef, undef, my $saddr, undef, @res) = @res;
+         my ($ipaddr, undef) = getnameinfo( $saddr, NI_NUMERICHOST | NI_NUMERICSERV);
+
+         $ipv4 = $ipaddr unless ($family != AF_INET || defined $ipv4);
+         $ipv6 = $ipaddr unless ($family != AF_INET6 || defined $ipv6);
+      }
+
+      return undef unless (defined $ipv4 || $ipv6);
+      return config_set('prefer_v4')
+         ? ($ipv4 ? $ipv4 : $ipv6)
+         : ($ipv6 ? $ipv6 : $ipv4);
    }else{ # IPv4
       my $ip = (gethostbyname($host))[4];
       return $ip ? inet_ntoa($ip) : undef;


### PR DESCRIPTION
This removes redundant, non implemented version to prefer IPv6 address. Prefering IPv6 addresses is default if Socket 6 is installed. So prefering IPv4 addresses could be sometimes useful, if ipv6 is broken in any way (missing Reverse DNS and whitelist on DNS on target IRC-Server ;))
